### PR TITLE
Capitalize module name

### DIFF
--- a/emptyparagraphkiller.info
+++ b/emptyparagraphkiller.info
@@ -1,4 +1,4 @@
-name = Empty paragraph killer
+name = Empty Paragraph Killer
 description = Provides a field formatter that filters out pesky empty paragraphs.
 backdrop = 1.x
 type = module


### PR DESCRIPTION
@markabur please refer to the "name" property documentation in https://docs.backdropcms.org/creating-modules#info-files

> Since module names are proper names, they should be capitalized as such (capitalize all words in the name - including any "helper" words, such as "the", "of", "for" etc.). So it should for example be "Cool Things For Sites"; not "cool things for sites", nor "Cool things for sites", nor "Cool Things for Sites").